### PR TITLE
Add "@reddit" to Message-Id in order to make nntpit work in Pan newsr…

### DIFF
--- a/comments.c
+++ b/comments.c
@@ -46,7 +46,7 @@ void json_article_to_mbox(json_object *article)
     fprintf(stdout, "From: %s\n", json_object_get_string_prop(article, "author"));
     fprintf(stdout, "Date: %s\n",  date);
     fprintf(stdout, "Subject: %s\n", json_object_get_string_prop(article, "title"));
-    fprintf(stdout, "Message-Id: <%s>\n", json_object_get_string_prop(article, "name"));
+    fprintf(stdout, "Message-Id: <%s@reddit>\n", json_object_get_string_prop(article, "name"));
     fprintf(stdout, "Newsgroups: %s", json_object_get_string_prop(article, "subreddit"));
 
     // Article could be crossposted, check for more groups.
@@ -161,7 +161,7 @@ int reddit_parse_comment(json_object *spool, json_object *comment, char **header
             "Subject: Re: %s\r\n"
             "Lines: %u\r\n"
             "Date: %s\r\n"
-            "Message-Id: <%s>\r\n"
+            "Message-Id: <%s@reddit>\r\n"
             "References: %s\r\n"
             "Newsgroups: %s\r\n"
             "Path: reddit!not-for-mail\r\n"
@@ -209,7 +209,7 @@ int reddit_parse_comment(json_object *spool, json_object *comment, char **header
             "Subject: %s\r\n"
             "Date: %s\r\n"
             "Lines: %u\r\n"
-            "Message-Id: <%s>\r\n"
+            "Message-Id: <%s@reddit>\r\n"
             "Newsgroups: %s\r\n"
             "Path: reddit!not-for-mail\r\n"
             "Content-Type: text/plain; charset=UTF-8\r\n"

--- a/nntpit.c
+++ b/nntpit.c
@@ -618,7 +618,7 @@ void handle_xover_cmd(client_t *cl, const char *param)
                 line_count = body ? str_count_newlines(body) : 0;
 
                 // TODO: calculate bytes, lines.
-                client_printf(cl, "%d\t%s\t%s\t%s\t<%s>\t%s\t%d\t%u\r\n",
+                client_printf(cl, "%d\t%s\t%s\t%s\t<%s@reddit>\t%s\t%d\t%u\r\n",
                                   i,
                                   json_object_get_string_prop(data, "title"),
                                   json_object_get_string_prop(data, "author"),

--- a/rfc5536.c
+++ b/rfc5536.c
@@ -47,7 +47,7 @@ int article_generate_references(json_object *spool, json_object *object, char **
         parentid = json_object_get_string_prop(data, "parent_id");
 
         // Append that to the list.
-        refs = g_strdup_printf("<%s>%s%s",
+        refs = g_strdup_printf("<%s@reddit>%s%s",
             parentid,
             **references != '\0' ? " " : "",
             *references);

--- a/subreddit.c
+++ b/subreddit.c
@@ -48,7 +48,7 @@ static void json_article_to_mbox(json_object *article)
     fprintf(stdout, "From: %s\n", json_object_get_string_prop(article, "author"));
     fprintf(stdout, "Date: %s\n",  date);
     fprintf(stdout, "Subject: %s\n", json_object_get_string_prop(article, "title"));
-    fprintf(stdout, "Message-Id: %s\n", json_object_get_string_prop(article, "name"));
+    fprintf(stdout, "Message-Id: <%s@reddit>\n", json_object_get_string_prop(article, "name"));
     fprintf(stdout, "Newsgroups: %s", json_object_get_string_prop(article, "subreddit")); // TODO: crosspost_parent_list
 
     // Crossposted?


### PR DESCRIPTION
…eader.

The Pan newsreader has a sanity check that the message ids have chars out of `<>@` in there.

nntpit didn't have `@`.

This patch adds `@reddit` to the message ids.
